### PR TITLE
Fix code:set issues with the dollar sign

### DIFF
--- a/src/Commands/SetCodeCommand.php
+++ b/src/Commands/SetCodeCommand.php
@@ -48,7 +48,7 @@ class SetCodeCommand extends Command
         $code = $this->argument('code');
 
         if ($this->validate($code)) {
-            $hash = str_replace(['\\','$'], ['', '\$'], Hash::make($code));
+            $hash = Hash::make($code);
             $this->setHashInEnvironmentFile($hash);
             $this->info(sprintf('Code: "%s" is set successfully.', $code));
         } else {
@@ -67,8 +67,8 @@ class SetCodeCommand extends Command
         $regex = '/UNDER_CONSTRUCTION_HASH=\S+/';
         $newLine = "UNDER_CONSTRUCTION_HASH=$hash";
 
-        if (preg_match($regex, $envContent)) {
-            $envContent =  preg_replace($regex, $newLine, $envContent);
+        if (preg_match($regex, $envContent, $matches)) {
+            $envContent = str_replace($matches[0], $newLine, $envContent);
         } else {
             $envContent .= "\n".$newLine."\n";
         }


### PR DESCRIPTION
- use str_replace instead of preg_replace so all `$int` sequences are kept

- fix issue that `$` signs are written to the .env file escaped

fixes #48 