### PR TITLE
Redirect to the intended url following a correct code entry

### DIFF
--- a/src/Controllers/CodeController.php
+++ b/src/Controllers/CodeController.php
@@ -57,7 +57,7 @@ class CodeController extends Controller
             'backButton'  => $this->config['back-button'],
             'showButton'  => $this->config['show-button'],
             'hideButton'  => $this->config['hide-button'],
-            'redirectUrl' => $this->config['redirect-url'],
+            'redirectUrl' => session()->get('intended.url', $this->config['redirect-url']),
         ]);
     }
 

--- a/src/UnderConstruction.php
+++ b/src/UnderConstruction.php
@@ -36,6 +36,7 @@ class UnderConstruction
 
         if (! $this->hasAccess($request)) {
             session(['intended.url' => url()->current()]);
+
             return new RedirectResponse('/under/construction');
         }
 

--- a/src/UnderConstruction.php
+++ b/src/UnderConstruction.php
@@ -35,6 +35,7 @@ class UnderConstruction
         }
 
         if (! $this->hasAccess($request)) {
+            session(['intended.url' => url()->current()]);
             return new RedirectResponse('/under/construction');
         }
 


### PR DESCRIPTION
Currently the default behaviour is that it always redirects to "/"

I found it more useful to redirect to the URL the user intended to visit prior to being shown the lock page. This is preferable in scenarios where multiple routes are lock-protected. If the lock page really is "/" then this naturally falls back to the default setting