### PR TITLE
Laravel 6.0, fixes, drop support for L5.7 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This Laravel package makes it possible to set your website in "Under Constructio
 
 ## Installation
 
-Begin by installing this package through Composer (Laravel 5.6, 5.7 and 5.8 compatible!).
+Begin by installing this package through Composer (Laravel 5.8 and 6.0 compatible!).
 
 ```bash
 composer require larsjanssen6/underconstruction

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
+        "php" : "^7.1.3",
+        "illuminate/support": "~5.8.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit": "^6.3|^7.0",
-        "mockery/mockery": "^1.0@dev",
+        "orchestra/testbench": "~3.8.0|^4.0",
+        "phpunit/phpunit": "^7.5|^8.0",
+        "mockery/mockery": "^1.0",
         "symfony/thanks": "^1.0"
     },
     "autoload-dev": {

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -29,7 +29,7 @@ trait Throttle
     protected function hasTooManyLoginAttempts(Request $request)
     {
         return $this->limiter()->tooManyAttempts(
-            $this->throttleKey($request), $this->maxAttempts(), $this->decayMinutes()
+            $this->throttleKey($request), $this->maxAttempts()
         );
     }
 
@@ -43,7 +43,7 @@ trait Throttle
     protected function incrementLoginAttempts(Request $request)
     {
         $this->limiter()->hit(
-            $this->throttleKey($request), $this->decayMinutes()
+            $this->throttleKey($request), $this->decayMinutes() * 60
         );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
 {
     protected $config = [];
 
-    public function setup()
+    public function setup(): void
     {
         parent::setup();
 


### PR DESCRIPTION
Drop support for L5.7 and below
Add support for Laravel 6.0
Fixed: calculating number of minutes to disable login
Fixed: tests
Update README.md