### PR TITLE
Modified to accept custom route prefix and custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ return [
     'title' => 'Under Construction',
 
     /*
+     * Custom Route Prefix
+     * */
+    'route-prefix' => env('UNDER_CONSTRUCTION_ROUTE_PREFIX','under'),
+
+    /*
+     * Custom Endpoint if you don't want to use 'construction'
+     * e.g. if you change to 'checkpoint', the route prefix
+     * above will be appended giving you 'under/checkpoint'
+     * */
+    'custom-endpoint' => env('UNDER_CONSTRUCTION_CUSTOM_ENDPOINT','construction'),
+
+
+    /*
      * Back button translation.
      */
     'back-button' => 'back',

--- a/config/under-construction.php
+++ b/config/under-construction.php
@@ -20,14 +20,14 @@ return [
     /*
      * Custom Route Prefix
      * */
-    'route-prefix' => env('UNDER_CONSTRUCTION_ROUTE_PREFIX','under'),
+    'route-prefix' => env('UNDER_CONSTRUCTION_ROUTE_PREFIX', 'under'),
 
     /*
      * Custom Endpoint if you don't want to use 'construction'
      * e.g. if you change to 'checkpoint', the route prefix
      * above will be appended giving you 'under/checkpoint'
      * */
-    'custom-endpoint' => env('UNDER_CONSTRUCTION_CUSTOM_ENDPOINT','construction'),
+    'custom-endpoint' => env('UNDER_CONSTRUCTION_CUSTOM_ENDPOINT', 'construction'),
 
     /*
      * Back button translation.
@@ -59,45 +59,45 @@ return [
      */
     'throttle' => true,
 
-        /*
-        |--------------------------------------------------------------------------
-        | Throttle settings (only when throttle is true)
-        |--------------------------------------------------------------------------
-        |
-        */
+    /*
+    |--------------------------------------------------------------------------
+    | Throttle settings (only when throttle is true)
+    |--------------------------------------------------------------------------
+    |
+    */
 
-        /*
-        * Set the amount of digits (max 6).
-        */
-        'total_digits' => 6,
+    /*
+    * Set the amount of digits (max 6).
+    */
+    'total_digits' => 6,
 
-        /*
-         * Set the maximum number of attempts to allow.
-         */
-        'max_attempts' => 3,
+    /*
+     * Set the maximum number of attempts to allow.
+     */
+    'max_attempts' => 3,
 
-        /*
-         * Show attempts left.
-         */
-        'show_attempts_left' => true,
+    /*
+     * Show attempts left.
+     */
+    'show_attempts_left' => true,
 
-        /*
-         * Attempts left message.
-         */
-        'attempts_message' => 'Attempts left: %i',
+    /*
+     * Attempts left message.
+     */
+    'attempts_message' => 'Attempts left: %i',
 
-        /*
-         * Too many attempts message.
-         */
-        'seconds_message' => 'Too many attempts please try again in %i seconds.',
+    /*
+     * Too many attempts message.
+     */
+    'seconds_message' => 'Too many attempts please try again in %i seconds.',
 
-        /*
-         * Set the number of minutes to disable login.
-         */
-        'decay_minutes' => 5,
+    /*
+     * Set the number of minutes to disable login.
+     */
+    'decay_minutes' => 5,
 
-        /*
-         * Prevent the site from being indexed by Robots when locked
-         */
-        'lock_robots' => true,
+    /*
+     * Prevent the site from being indexed by Robots when locked
+     */
+    'lock_robots' => true,
 ];

--- a/config/under-construction.php
+++ b/config/under-construction.php
@@ -18,6 +18,18 @@ return [
     'title' => 'Under Construction',
 
     /*
+     * Custom Route Prefix
+     * */
+    'route-prefix' => env('UNDER_CONSTRUCTION_ROUTE_PREFIX','under'),
+
+    /*
+     * Custom Endpoint if you don't want to use 'construction'
+     * e.g. if you change to 'checkpoint', the route prefix
+     * above will be appended giving you 'under/checkpoint'
+     * */
+    'custom-endpoint' => env('UNDER_CONSTRUCTION_CUSTOM_ENDPOINT','construction'),
+
+    /*
      * Back button translation.
      */
     'back-button' => 'back',

--- a/resources/assets/UnderConstruction.vue
+++ b/resources/assets/UnderConstruction.vue
@@ -125,7 +125,7 @@
                     this.setNumber(number);
                     if(this.codeIsComplete()) {
                         this.isLoading = true;
-                        axios.post("/under/check", { "code": this.real_code.join("") })
+                        axios.post("check", { "code": this.real_code.join("") })
                             .then(() => {
                                 this.success = true;
                                 window.location.href = this.redirectUrl;
@@ -269,7 +269,7 @@
              */
             checkIfLimited() {
                 this.isLoading = true;
-                axios.post("/under/checkiflimited")
+                axios.post("checkiflimited")
                     .catch((error) => {
                         this.wrongCode = true;
                         setTimeout(() => this.wrongCode = false, 5000);

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -34,6 +34,6 @@
     </under-construction>
 </div>
 
-<script src="/under/js"></script>
+<script src="/{{config('under-construction.route-prefix')}}/js"></script>
 </body>
 </html>

--- a/src/UnderConstruction.php
+++ b/src/UnderConstruction.php
@@ -30,7 +30,7 @@ class UnderConstruction
      */
     public function handle($request, Closure $next)
     {
-        if ($request->is('under/*')) {
+        if ($request->is($this->config['route-prefix'].'/*')) {
             return $next($request);
         }
 
@@ -41,7 +41,7 @@ class UnderConstruction
         if (! $this->hasAccess($request)) {
             session(['intended.url' => url()->current()]);
 
-            return new RedirectResponse('/under/construction');
+            return new RedirectResponse($this->config['route-prefix'].'/'.$this->config['custom-endpoint']);
         }
 
         return $next($request);

--- a/src/UnderConstructionServiceProvider.php
+++ b/src/UnderConstructionServiceProvider.php
@@ -32,7 +32,7 @@ class UnderConstructionServiceProvider extends ServiceProvider
 
         $routeConfig = [
             'namespace'  => 'LarsJanssen\UnderConstruction\Controllers',
-            'prefix'     => 'under',
+            'prefix'     => config('under-construction.route-prefix'),
             'middleware' => [
                 'web',
             ],
@@ -49,7 +49,7 @@ class UnderConstructionServiceProvider extends ServiceProvider
                 'as' => 'underconstruction.checkiflimited',
             ]);
 
-            $router->get('construction', [
+            $router->get(config('under-construction.custom-endpoint'), [
                 'uses' => 'CodeController@index',
                 'as'   => 'underconstruction.index',
             ]);

--- a/tests/Integration/UnderConstructionModeTest.php
+++ b/tests/Integration/UnderConstructionModeTest.php
@@ -98,6 +98,6 @@ class UnderConstructionModeTest extends TestCase
         $this->get('/test')
             ->assertSessionMissing('can_visit')
             ->assertRedirect()
-            ->assertHeader('location', '/under/construction');
+            ->assertHeader('location', 'under/construction');
     }
 }


### PR DESCRIPTION
I modified this package to accept custom route prefix and custom endpoint.  For example, if you want the default page to use `auth/checkpoint`, you can just add these to your .env file 

```
UNDER_CONSTRUCTION_ROUTE_PREFIX = 'auth'  
UNDER_CONSTRUCTION_CUSTOM_ENDPOINT = 'checkpoint'
```
**NB**: These modifications doesn't change the normal behavior of the package.

![Annotation 2019-10-28 211746](https://user-images.githubusercontent.com/13623015/67718992-dabb6380-f9c8-11e9-9d7c-c8adc7787a82.jpg)

