### PR TITLE
Fix namespace collision on Laravel 8.10

### DIFF
--- a/src/Commands/SetCodeCommand.php
+++ b/src/Commands/SetCodeCommand.php
@@ -82,9 +82,9 @@ class SetCodeCommand extends Command
 
         if (preg_match($regex, $envContent)) {
             $hash = str_replace(['\\', '$'], ['', '\$'], $hash);
-            $envContent = preg_replace($regex, $this->newLine($hash), $envContent);
+            $envContent = preg_replace($regex, $this->displayHash($hash), $envContent);
         } else {
-            $envContent .= "\n".$this->newLine($hash)."\n";
+            $envContent .= "\n".$this->displayHash($hash)."\n";
         }
 
         $this->filesystem->put($envPath, $envContent);
@@ -94,7 +94,7 @@ class SetCodeCommand extends Command
      * @param $hash
      * @return string
      */
-    private function newLine($hash)
+    private function displayHash($hash)
     {
         return "UNDER_CONSTRUCTION_HASH=$hash";
     }


### PR DESCRIPTION
Hello,

Tried to install with `composer require larsjanssen6/underconstruction` and got the following error:
```
PHP Fatal error:  Access level to LarsJanssen\UnderConstruction\Commands\SetCodeCommand::newLine() must be public (as in class Illuminate\Console\Command) in /.../vendor/larsjanssen6/underconstruction/src/Commands/SetCodeCommand.php on line 97

   Symfony\Component\ErrorHandler\Error\FatalError 

  Access level to LarsJanssen\UnderConstruction\Commands\SetCodeCommand::newLine() must be public (as in class Illuminate\Console\Command)
```

Pretty sure the private `newLine()` method in `SetCodeCommand` conflicts with something in Illuminate. Changed the name of the method and it works fine for me.